### PR TITLE
refactor: Update DownloadOptions component to use option name instead of type

### DIFF
--- a/src/app/doc-truyen/_components/download-options.tsx
+++ b/src/app/doc-truyen/_components/download-options.tsx
@@ -23,14 +23,14 @@ export default function DownloadOptions({ chapterURL }: DownloadOptionsProps) {
   return (
     <ul className="space-y-2 text-sm">
       {data.map((option) => (
-        <li key={option.path}>
+        <li key={option.name}>
           <Link
-            href={`${API_URL}${option.path}?url=${chapterURL}`}
+            href={`${API_URL}/download?type=${option.name}&url=${chapterURL}`}
             className="flex items-center gap-1.5"
             target="_blank"
           >
             <DownloadIcon className="text-fg-500 size-4" />
-            <span>{capitalize(option.type)}</span>
+            <span>{capitalize(option.name)}</span>
           </Link>
         </li>
       ))}

--- a/src/data/get-download-options.ts
+++ b/src/data/get-download-options.ts
@@ -23,7 +23,7 @@ export async function getDownloadOptions(): Promise<TDownloadOption[]> {
 
     const err = new Error();
     err.name = errorCode;
-    err.message = reason || "Failed to fetch plugin list";
+    err.message = reason || "Failed to fetch download option list";
     reportError(err);
 
     return [];

--- a/src/types/download-option.ts
+++ b/src/types/download-option.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
 export const ZDownloadOption = z.object({
-  type: z.string(),
-  path: z.string(),
-  description: z.string(),
+  name: z.string(),
 });
 
 export type TDownloadOption = z.infer<typeof ZDownloadOption>;


### PR DESCRIPTION
This commit updates the DownloadOptions component to use the option name instead of the option type when rendering the download options. The option name is now capitalized using the capitalize function for consistency. This change improves code clarity and maintainability by using a more descriptive property name.